### PR TITLE
feat: Make IFeatureClient interface public.

### DIFF
--- a/src/OpenFeature/IFeatureClient.cs
+++ b/src/OpenFeature/IFeatureClient.cs
@@ -4,24 +4,124 @@ using OpenFeature.Model;
 
 namespace OpenFeature
 {
-    internal interface IFeatureClient
+    /// <summary>
+    /// Interface used to resolve flags of varying types.
+    /// </summary>
+    public interface IFeatureClient
     {
+        /// <summary>
+        /// Appends hooks to client
+        /// <para>
+        /// The appending operation will be atomic.
+        /// </para>
+        /// </summary>
+        /// <param name="hooks">A list of Hooks that implement the <see cref="Hook"/> interface</param>
         void AddHooks(IEnumerable<Hook> hooks);
+
+        /// <summary>
+        /// Gets client metadata
+        /// </summary>
+        /// <returns>Client metadata <see cref="ClientMetadata"/></returns>
         ClientMetadata GetMetadata();
 
+        /// <summary>
+        /// Resolves a boolean feature flag
+        /// </summary>
+        /// <param name="flagKey">Feature flag key</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
+        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         Task<bool> GetBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+
+        /// <summary>
+        /// Resolves a boolean feature flag
+        /// </summary>
+        /// <param name="flagKey">Feature flag key</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
+        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         Task<FlagEvaluationDetails<bool>> GetBooleanDetails(string flagKey, bool defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
 
+        /// <summary>
+        /// Resolves a string feature flag
+        /// </summary>
+        /// <param name="flagKey">Feature flag key</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
+        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         Task<string> GetStringValue(string flagKey, string defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+
+        /// <summary>
+        /// Resolves a string feature flag
+        /// </summary>
+        /// <param name="flagKey">Feature flag key</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
+        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         Task<FlagEvaluationDetails<string>> GetStringDetails(string flagKey, string defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
 
+        /// <summary>
+        /// Resolves a integer feature flag
+        /// </summary>
+        /// <param name="flagKey">Feature flag key</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
+        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         Task<int> GetIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+
+        /// <summary>
+        /// Resolves a integer feature flag
+        /// </summary>
+        /// <param name="flagKey">Feature flag key</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
+        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         Task<FlagEvaluationDetails<int>> GetIntegerDetails(string flagKey, int defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
 
+        /// <summary>
+        /// Resolves a double feature flag
+        /// </summary>
+        /// <param name="flagKey">Feature flag key</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
+        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         Task<double> GetDoubleValue(string flagKey, double defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+
+        /// <summary>
+        /// Resolves a double feature flag
+        /// </summary>
+        /// <param name="flagKey">Feature flag key</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
+        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         Task<FlagEvaluationDetails<double>> GetDoubleDetails(string flagKey, double defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
 
+        /// <summary>
+        /// Resolves a structure object feature flag
+        /// </summary>
+        /// <param name="flagKey">Feature flag key</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
+        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         Task<Value> GetObjectValue(string flagKey, Value defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
+
+        /// <summary>
+        /// Resolves a structure object feature flag
+        /// </summary>
+        /// <param name="flagKey">Feature flag key</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
+        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
+        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
         Task<FlagEvaluationDetails<Value>> GetObjectDetails(string flagKey, Value defaultValue, EvaluationContext context = null, FlagEvaluationOptions config = null);
     }
 }

--- a/src/OpenFeature/OpenFeatureClient.cs
+++ b/src/OpenFeature/OpenFeatureClient.cs
@@ -97,10 +97,7 @@ namespace OpenFeature
             this._evaluationContext = context ?? EvaluationContext.Empty;
         }
 
-        /// <summary>
-        /// Gets client metadata
-        /// </summary>
-        /// <returns>Client metadata <see cref="ClientMetadata"/></returns>
+        /// <inheritdoc />
         public ClientMetadata GetMetadata() => this._metadata;
 
         /// <summary>
@@ -113,13 +110,7 @@ namespace OpenFeature
         /// <param name="hook">Hook that implements the <see cref="Hook"/> interface</param>
         public void AddHooks(Hook hook) => this._hooks.Push(hook);
 
-        /// <summary>
-        /// Appends hooks to client
-        /// <para>
-        /// The appending operation will be atomic.
-        /// </para>
-        /// </summary>
-        /// <param name="hooks">A list of Hooks that implement the <see cref="Hook"/> interface</param>
+        /// <inheritdoc />
         public void AddHooks(IEnumerable<Hook> hooks) => this._hooks.PushRange(hooks.ToArray());
 
         /// <summary>
@@ -138,131 +129,61 @@ namespace OpenFeature
         /// </summary>
         public void ClearHooks() => this._hooks.Clear();
 
-        /// <summary>
-        /// Resolves a boolean feature flag
-        /// </summary>
-        /// <param name="flagKey">Feature flag key</param>
-        /// <param name="defaultValue">Default value</param>
-        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
-        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
-        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
+        /// <inheritdoc />
         public async Task<bool> GetBooleanValue(string flagKey, bool defaultValue, EvaluationContext context = null,
             FlagEvaluationOptions config = null) =>
             (await this.GetBooleanDetails(flagKey, defaultValue, context, config)).Value;
 
-        /// <summary>
-        /// Resolves a boolean feature flag
-        /// </summary>
-        /// <param name="flagKey">Feature flag key</param>
-        /// <param name="defaultValue">Default value</param>
-        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
-        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
-        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
+        /// <inheritdoc />
         public async Task<FlagEvaluationDetails<bool>> GetBooleanDetails(string flagKey, bool defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null) =>
             await this.EvaluateFlag(this.ExtractProvider<bool>(provider => provider.ResolveBooleanValue),
                 FlagValueType.Boolean, flagKey,
                 defaultValue, context, config);
 
-        /// <summary>
-        /// Resolves a string feature flag
-        /// </summary>
-        /// <param name="flagKey">Feature flag key</param>
-        /// <param name="defaultValue">Default value</param>
-        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
-        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
-        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
+        /// <inheritdoc />
         public async Task<string> GetStringValue(string flagKey, string defaultValue, EvaluationContext context = null,
             FlagEvaluationOptions config = null) =>
             (await this.GetStringDetails(flagKey, defaultValue, context, config)).Value;
 
-        /// <summary>
-        /// Resolves a string feature flag
-        /// </summary>
-        /// <param name="flagKey">Feature flag key</param>
-        /// <param name="defaultValue">Default value</param>
-        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
-        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
-        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
+        /// <inheritdoc />
         public async Task<FlagEvaluationDetails<string>> GetStringDetails(string flagKey, string defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null) =>
             await this.EvaluateFlag(this.ExtractProvider<string>(provider => provider.ResolveStringValue),
                 FlagValueType.String, flagKey,
                 defaultValue, context, config);
 
-        /// <summary>
-        /// Resolves a integer feature flag
-        /// </summary>
-        /// <param name="flagKey">Feature flag key</param>
-        /// <param name="defaultValue">Default value</param>
-        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
-        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
-        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
+        /// <inheritdoc />
         public async Task<int> GetIntegerValue(string flagKey, int defaultValue, EvaluationContext context = null,
             FlagEvaluationOptions config = null) =>
             (await this.GetIntegerDetails(flagKey, defaultValue, context, config)).Value;
 
-        /// <summary>
-        /// Resolves a integer feature flag
-        /// </summary>
-        /// <param name="flagKey">Feature flag key</param>
-        /// <param name="defaultValue">Default value</param>
-        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
-        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
-        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
+        /// <inheritdoc />
         public async Task<FlagEvaluationDetails<int>> GetIntegerDetails(string flagKey, int defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null) =>
             await this.EvaluateFlag(this.ExtractProvider<int>(provider => provider.ResolveIntegerValue),
                 FlagValueType.Number, flagKey,
                 defaultValue, context, config);
 
-        /// <summary>
-        /// Resolves a double feature flag
-        /// </summary>
-        /// <param name="flagKey">Feature flag key</param>
-        /// <param name="defaultValue">Default value</param>
-        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
-        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
-        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
+        /// <inheritdoc />
         public async Task<double> GetDoubleValue(string flagKey, double defaultValue,
             EvaluationContext context = null,
             FlagEvaluationOptions config = null) =>
             (await this.GetDoubleDetails(flagKey, defaultValue, context, config)).Value;
 
-        /// <summary>
-        /// Resolves a double feature flag
-        /// </summary>
-        /// <param name="flagKey">Feature flag key</param>
-        /// <param name="defaultValue">Default value</param>
-        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
-        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
-        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
+        /// <inheritdoc />
         public async Task<FlagEvaluationDetails<double>> GetDoubleDetails(string flagKey, double defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null) =>
             await this.EvaluateFlag(this.ExtractProvider<double>(provider => provider.ResolveDoubleValue),
                 FlagValueType.Number, flagKey,
                 defaultValue, context, config);
 
-        /// <summary>
-        /// Resolves a structure object feature flag
-        /// </summary>
-        /// <param name="flagKey">Feature flag key</param>
-        /// <param name="defaultValue">Default value</param>
-        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
-        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
-        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
+        /// <inheritdoc />
         public async Task<Value> GetObjectValue(string flagKey, Value defaultValue, EvaluationContext context = null,
             FlagEvaluationOptions config = null) =>
             (await this.GetObjectDetails(flagKey, defaultValue, context, config)).Value;
 
-        /// <summary>
-        /// Resolves a structure object feature flag
-        /// </summary>
-        /// <param name="flagKey">Feature flag key</param>
-        /// <param name="defaultValue">Default value</param>
-        /// <param name="context"><see cref="EvaluationContext">Evaluation Context</see></param>
-        /// <param name="config"><see cref="EvaluationContext">Flag Evaluation Options</see></param>
-        /// <returns>Resolved flag details <see cref="FlagEvaluationDetails{T}"/></returns>
+        /// <inheritdoc />
         public async Task<FlagEvaluationDetails<Value>> GetObjectDetails(string flagKey, Value defaultValue,
             EvaluationContext context = null, FlagEvaluationOptions config = null) =>
             await this.EvaluateFlag(this.ExtractProvider<Value>(provider => provider.ResolveStructureValue),


### PR DESCRIPTION
Signed-off-by: Chris Donnelly <cdonnellytx@users.noreply.github.com>

## This PR

- Exposes the `IFeatureClient` interface to consumers by making it public.
- Pulls up the XMLDoc from the concrete class to the interface, filling in gaps (e.g., the interface-level docs) from the Java SDK.

### Background and Motivation

This allows consumers using dependency injection to properly create a mock of the feature client.  Currently, the exposed `FeatureClient` class is sealed, therefore making it extremely difficult ([though not impossible](https://stackoverflow.com/a/12187583)) for consumers to mock in parallel without side-effects.

Consider

```csharp
public class MyService
{
    private readonly FeatureClient _featureClient;

    public MyService(FeatureClient featureClient, ...)
    {
        _featureClient = featureClient;
    }

    public async Task<int> DoSomethingAsync() => await _featureClient.GetBooleanValue("flag") ? 42 : 47;
}
```

A unit test for `MyService` would be dependent on the concrete `FeatureClient` class, and thus on the `Api.Instance` singleton, limiting tests to be more brittle and dependent on state.

Allowing `MyService` to use `IFeatureClient` would get around this problem, and allow for unit tests to not depend on shared state, allowing for test parallelization where possible.

### Notes

Modifying a public interface in any way (even adding new methods/properties) is considered a breaking change, so each client surface enhancement/change would be breaking by that definition.  We may wish to pull up methods from the concrete class to the interface (e.g., `GetContext` / `SetContext`) now before committing to the existing interface. 

### Follow-up Tasks

Avoiding unrelated changes is also why I opted not to make `GetMetadata()` into a `Metadata` read-only property on the interface -- while this makes sense from a .NET idiomatic view, it would conflict with the current way the concrete class exposes `GetMetadata()`.  Fixing it later would be a breaking change, though.

Similarly, I opted to keep `Api.Instance.GetClient()` returning the concrete class, as it would be a breaking change to make it return `IFeatureClient`.  I am open to that idea, though.

### How to test

No additional tests should be necessary at this time.